### PR TITLE
Renames randomization to events

### DIFF
--- a/exts/ext_template/ext_template/tasks/locomotion/velocity/config/anymal_d/flat_env_cfg.py
+++ b/exts/ext_template/ext_template/tasks/locomotion/velocity/config/anymal_d/flat_env_cfg.py
@@ -34,5 +34,5 @@ class AnymalDFlatEnvCfg_PLAY(AnymalDFlatEnvCfg):
         # disable randomization for play
         self.observations.policy.enable_corruption = False
         # remove random pushing
-        self.randomization.base_external_force_torque = None
-        self.randomization.push_robot = None
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None

--- a/exts/ext_template/ext_template/tasks/locomotion/velocity/config/anymal_d/rough_env_cfg.py
+++ b/exts/ext_template/ext_template/tasks/locomotion/velocity/config/anymal_d/rough_env_cfg.py
@@ -37,5 +37,5 @@ class AnymalDRoughEnvCfg_PLAY(AnymalDRoughEnvCfg):
         # disable randomization for play
         self.observations.policy.enable_corruption = False
         # remove random pushing
-        self.randomization.base_external_force_torque = None
-        self.randomization.push_robot = None
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None


### PR DESCRIPTION
`base_external_force_torque ` and `push_robot` don't belong to `randomization`

rename to `events`