### PR TITLE
Fixes the difference between README and asked path during vscode setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ python -m pip install -e .
 
 To setup the IDE, please follow these instructions:
 
-- Run VSCode Tasks, by pressing `Ctrl+Shift+P`, selecting `Tasks: Run Task` and running the `setup_python_env` in the drop down menu. When running this task, you will be prompted to add the absolute path to your Isaac Lab installation.
+- Run VSCode Tasks, by pressing `Ctrl+Shift+P`, selecting `Tasks: Run Task` and running the `setup_python_env` in the drop down menu. When running this task, you will be prompted to add the absolute path to your Isaac Sim installation.
 
 If everything executes correctly, it should create a file .python.env in the .vscode directory. The file contains the python paths to all the extensions provided by Isaac Sim and Omniverse. This helps in indexing all the python modules for intelligent suggestions while writing code.
 


### PR DESCRIPTION
Corrects the path in the README from Isaac Lab to Isaac Sim

Fixes: #26 