### PR TITLE
bugfix: update broken docker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To enable your extension, follow these steps:
 ### Building Isaac Lab Base Image
 
 Currently, we don't have the Docker for Isaac Lab publicly available. Hence, you'd need to build the docker image
-for Isaac Lab locally by following the steps [here](https://isaac-sim.github.io/IsaacLab/source/deployment/index.html).
+for Isaac Lab locally by following the steps [here](https://isaac-sim.github.io/IsaacLab/main/source/deployment/run_docker_example.html).
 
 Once you have built the base Isaac Lab image, you can check it exists by doing:
 


### PR DESCRIPTION
The link for building the Isaac Lab base image is dead:
https://isaac-sim.github.io/IsaacLab/source/deployment/docker.html

Interestingly if you google how to build the isaac lab docker image the first result is also that dead link.

This pr updates the link to:
https://isaac-sim.github.io/IsaacLab/main/source/deployment/run_docker_example.html

which has instructions for building. 