### PR TITLE
fix(task path): Update tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
         {
             "id": "isaac_path",
             "description": "Absolute path to the current Isaac Sim installation. Can be skipped if Isaac Sim installed from pip.",
-            "default": "${HOME}/.local/share/ov/pkg/isaac_sim-4.2.0",
+            "default": "${HOME}/.local/share/ov/pkg/isaac-sim-4.2.0",
             "type": "promptString"
         },
     ]


### PR DESCRIPTION
Correct the default path to Isaac Sim (installed using binaries) in .vscode/task.json