### PR TITLE
Fixes typo in extension.toml

### DIFF
--- a/source/ext_template/config/extension.toml
+++ b/source/ext_template/config/extension.toml
@@ -17,7 +17,7 @@ keywords = ["extension", "template", "isaaclab"]
 [dependencies]
 "isaaclab" = {}
 "isaaclab_assets" = {}
-"isaclab_mimic" = {}
+"isaaclab_mimic" = {}
 "isaaclab_rl" = {}
 "isaaclab_tasks" = {}
 # NOTE: Add additional dependencies here


### PR DESCRIPTION
Fixes a typo in extension.toml for isaaclab_mimic that is preventing the extension from being found.

Fixes #50 